### PR TITLE
Fix trigger on all branch, tag, and pr patterns

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,12 +3,12 @@ name: main
 on:
   push:
     branches:
-    - '*'
+    - '**'
     tags:
-    - '*'
+    - '**'
   pull_request:
     branches:
-    - '*'
+    - '**'
 
 jobs:
   build:


### PR DESCRIPTION
Quoting from [Workflow syntax for GitHub Actions](https://help.github.com/en/github/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet):

>* \* matches zero or more characters, but does not match the / character
>* \** matches zero or more of any character

The current trigger pattern does not allow CI builds for branch names containing the `/` character. This patch will allow just that.